### PR TITLE
Export TransportState, ValidTransportState

### DIFF
--- a/src/Network/Transport/InMemory.hs
+++ b/src/Network/Transport/InMemory.hs
@@ -7,6 +7,8 @@ module Network.Transport.InMemory
   , createTransportExposeInternals
   -- * For testing purposes
   , TransportInternals(..)
+  , TransportState(..)
+  , ValidTransportState(..)
   , breakConnection
   ) where
 


### PR DESCRIPTION
createTransportStateExposeInternals is somewhat useless without these
exports. Alternatively, we could make an Internal module and only export
from there.